### PR TITLE
PNC batch job does not count meta_data correctly

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/client/JurorServiceClientImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/client/JurorServiceClientImpl.java
@@ -34,15 +34,16 @@ public class JurorServiceClientImpl extends AbstractRemoteRestClient implements 
     }
 
     @Override
-    public void call(String jurorNumber, Payload payload) {
+    public PoliceCheckStatusDto call(String jurorNumber, PoliceCheckStatusDto payload) {
         log.debug("Updating juror: " + jurorNumber + " pnc check result on juror service backend");
-        HttpEntity<Payload> requestUpdate = new HttpEntity<>(payload);
-        ResponseEntity<Void> response =
-            restTemplate.exchange(url, HttpMethod.PATCH, requestUpdate, Void.class, jurorNumber);
+        HttpEntity<PoliceCheckStatusDto> requestUpdate = new HttpEntity<>(payload);
+        ResponseEntity<PoliceCheckStatusDto> response =
+            restTemplate.exchange(url, HttpMethod.PATCH, requestUpdate, PoliceCheckStatusDto.class, jurorNumber);
         final HttpStatusCode statusCode = response.getStatusCode();
         if (!statusCode.equals(HttpStatus.ACCEPTED)) {
             throw new RemoteGatewayException("Call to JurorServiceClient failed status code was: " + statusCode);
         }
         log.debug("Successfully updating juror: " + jurorNumber + " pnc check result on juror service backend");
+        return response.getBody();
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/client/contracts/JurorServiceClient.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/client/contracts/JurorServiceClient.java
@@ -8,12 +8,13 @@ import uk.gov.hmcts.juror.standard.client.contract.Client;
 
 public interface JurorServiceClient extends Client {
 
-    void call(String jurorNumber, Payload result);
+    PoliceCheckStatusDto call(String jurorNumber, PoliceCheckStatusDto result);
 
     @AllArgsConstructor
     @Getter
     @EqualsAndHashCode
-    class Payload {
+    class PoliceCheckStatusDto {
         private PoliceNationalComputerCheckResult.Status status;
     }
 }
+

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/model/PoliceNationalComputerCheckResult.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/model/PoliceNationalComputerCheckResult.java
@@ -6,6 +6,7 @@ import lombok.Data;
 public class PoliceNationalComputerCheckResult {
     private Status status;
     private String message;
+    private boolean isMaxRetiresExceed;
 
     public PoliceNationalComputerCheckResult(Status status, String message) {
         this.status = status;
@@ -33,6 +34,7 @@ public class PoliceNationalComputerCheckResult {
         ERROR_RETRY_OTHER_ERROR_CODE,
         ERROR_RETRY_NO_ERROR_REASON,
         ERROR_RETRY_UNEXPECTED_EXCEPTION,
-        ERROR_RETRY_FAILED_TO_UPDATE_BACKEND;
+        ERROR_RETRY_FAILED_TO_UPDATE_BACKEND,
+        UNCHECKED_MAX_RETRIES_EXCEEDED;
     }
 }

--- a/src/test/java/uk/gov/hmcts/juror/pnc/check/client/JurorServiceClientImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/pnc/check/client/JurorServiceClientImplTest.java
@@ -32,7 +32,7 @@ class JurorServiceClientImplTest {
     @MockBean
     private RestTemplate restTemplate;
     @MockBean
-    private ResponseEntity<Void> response;
+    private ResponseEntity<JurorServiceClient.PoliceCheckStatusDto> response;
 
     private JurorServiceClientImpl jurorServiceClient;
 
@@ -53,10 +53,11 @@ class JurorServiceClientImplTest {
 
     @Test
     void positiveValidResponse() {
-        JurorServiceClient.Payload payload = new JurorServiceClient.Payload(
+        JurorServiceClient.PoliceCheckStatusDto payload = new JurorServiceClient.PoliceCheckStatusDto(
             PoliceNationalComputerCheckResult.Status.ELIGIBLE);
 
-        when(restTemplate.exchange(eq(URL), eq(HttpMethod.PATCH), any(), eq(Void.class),
+        when(restTemplate.exchange(eq(URL), eq(HttpMethod.PATCH), any(),
+            eq(JurorServiceClient.PoliceCheckStatusDto.class),
             eq(TestConstants.JUROR_NUMBER)))
             .thenReturn(response);
         when(response.getStatusCode()).thenReturn(HttpStatus.ACCEPTED);
@@ -68,9 +69,11 @@ class JurorServiceClientImplTest {
 
     @Test
     void positiveInvalidResponse() {
-        JurorServiceClient.Payload payload = new JurorServiceClient.Payload(
+        JurorServiceClient.PoliceCheckStatusDto payload = new JurorServiceClient.PoliceCheckStatusDto(
             PoliceNationalComputerCheckResult.Status.ELIGIBLE);
-        when(restTemplate.exchange(eq(URL), eq(HttpMethod.PATCH), any(), eq(Void.class),
+
+        when(restTemplate.exchange(eq(URL), eq(HttpMethod.PATCH), any(),
+            eq(JurorServiceClient.PoliceCheckStatusDto.class),
             eq(TestConstants.JUROR_NUMBER)))
             .thenReturn(response);
         when(response.getStatusCode()).thenReturn(HttpStatus.NOT_FOUND);

--- a/src/test/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImplTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -75,6 +76,8 @@ class PoliceNationalComputerCheckServiceImplTest {
             getPersonDetailsMapper,
             ruleService
         ));
+        when(this.jurorServiceClient.call(any(), any())).thenReturn(new JurorServiceClient.PoliceCheckStatusDto(
+            PoliceNationalComputerCheckResult.Status.ELIGIBLE));
     }
 
 
@@ -647,7 +650,8 @@ class PoliceNationalComputerCheckServiceImplTest {
 
             verify(jurorServiceClient, times(1)).call(
                 jurorCheckDetails.getJurorNumber(),
-                new JurorServiceClient.Payload(PoliceNationalComputerCheckResult.Status.ERROR_RETRY_NAME_HAS_NUMERICS)
+                new JurorServiceClient.PoliceCheckStatusDto(
+                    PoliceNationalComputerCheckResult.Status.ERROR_RETRY_NAME_HAS_NUMERICS)
             );
         }
 
@@ -676,7 +680,7 @@ class PoliceNationalComputerCheckServiceImplTest {
 
             verify(jurorServiceClient, times(1)).call(
                 jurorCheckDetails.getJurorNumber(),
-                new JurorServiceClient.Payload(
+                new JurorServiceClient.PoliceCheckStatusDto(
                     PoliceNationalComputerCheckResult.Status.ERROR_RETRY_UNEXPECTED_EXCEPTION)
             );
         }
@@ -706,7 +710,8 @@ class PoliceNationalComputerCheckServiceImplTest {
 
             verify(jurorServiceClient, times(1)).call(
                 jurorCheckDetails.getJurorNumber(),
-                new JurorServiceClient.Payload(PoliceNationalComputerCheckResult.Status.ERROR_RETRY_CONNECTION_ERROR)
+                new JurorServiceClient.PoliceCheckStatusDto(
+                    PoliceNationalComputerCheckResult.Status.ERROR_RETRY_CONNECTION_ERROR)
             );
         }
 
@@ -739,7 +744,7 @@ class PoliceNationalComputerCheckServiceImplTest {
 
             verify(jurorServiceClient, times(1)).call(
                 jurorCheckDetails.getJurorNumber(),
-                new JurorServiceClient.Payload(PoliceNationalComputerCheckResult.Status.ELIGIBLE)
+                new JurorServiceClient.PoliceCheckStatusDto(PoliceNationalComputerCheckResult.Status.ELIGIBLE)
             );
         }
     }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7297)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=%pullRequestNumber%)


### Change description ###
PNC scheduler batch job reports MAX_RETRIES_EXCEEDED count as 0 even when there are jurors updated to that status. It counts them in the {{TOTAL_WITH_STATUS_ERROR_RETRY_OTHER_ERROR_CODE}}



!Screenshot 2024-05-15 at 15.27.22.png|width=100%,alt="Screenshot 2024-05-15 at 15.27.22.png"!



!Screenshot 2024-05-15 at 15.29.31.png|width=91.66666666666666%,alt="Screenshot 2024-05-15 at 15.29.31.png"!



!Screenshot 2024-05-15 at 15.25.32.png|width=75%,alt="Screenshot 2024-05-15 at 15.25.32.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
