### PR TITLE
PNC batch job does not count meta_data correctly

### DIFF
--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
@@ -142,21 +142,24 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
         metaDataMap.put("TOTAL_CHECKS_IN_BATCH", String.valueOf(jurorCheckBatch.getJurorCheckDetails().size()));
         metaDataMap.put("TOTAL_NULL_RESULTS", String.valueOf(totalNullResults));
 
-        metaDataMap.put("TOTAL_WITH_STATUS_" + PoliceNationalComputerCheckResult.Status.UNCHECKED_MAX_RETRIES_EXCEEDED,
-            String.valueOf(jurorCheckBatch.getJurorCheckDetails().stream()
-                .filter(details -> details.getResult() != null)
-                .filter(details -> details.getResult().isMaxRetiresExceed())
-                .count()));
-
         Map<PoliceNationalComputerCheckResult.Status, Long> countMap = jurorCheckBatch.getJurorCheckDetails().stream()
             .filter(details -> details.getResult() != null)
             .collect(Collectors.groupingBy(o -> o.getResult().getStatus(), Collectors.counting()));
 
         for (PoliceNationalComputerCheckResult.Status resultStatus :
             PoliceNationalComputerCheckResult.Status.values()) {
+            if(resultStatus == PoliceNationalComputerCheckResult.Status.UNCHECKED_MAX_RETRIES_EXCEEDED) {
+                continue;
+            }
             long count = countMap.getOrDefault(resultStatus, 0L);
             metaDataMap.put("TOTAL_WITH_STATUS_" + resultStatus.name(), String.valueOf(count));
         }
+
+        metaDataMap.put("TOTAL_WITH_STATUS_" + PoliceNationalComputerCheckResult.Status.UNCHECKED_MAX_RETRIES_EXCEEDED,
+            String.valueOf(jurorCheckBatch.getJurorCheckDetails().stream()
+                .filter(details -> details.getResult() != null)
+                .filter(details -> details.getResult().isMaxRetiresExceed())
+                .count()));
 
         this.jobExecutionServiceClient.call(
             new JobExecutionServiceClient.StatusUpdatePayload(status, "Juror check completed.", metaDataMap),

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
@@ -148,7 +148,7 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
 
         for (PoliceNationalComputerCheckResult.Status resultStatus :
             PoliceNationalComputerCheckResult.Status.values()) {
-            if(resultStatus == PoliceNationalComputerCheckResult.Status.UNCHECKED_MAX_RETRIES_EXCEEDED) {
+            if (resultStatus == PoliceNationalComputerCheckResult.Status.UNCHECKED_MAX_RETRIES_EXCEEDED) {
                 continue;
             }
             long count = countMap.getOrDefault(resultStatus, 0L);


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7297)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=175)


### Change description ###
PNC scheduler batch job reports MAX_RETRIES_EXCEEDED count as 0 even when there are jurors updated to that status. It counts them in the {{TOTAL_WITH_STATUS_ERROR_RETRY_OTHER_ERROR_CODE}}



!Screenshot 2024-05-15 at 15.27.22.png|width=100%,alt="Screenshot 2024-05-15 at 15.27.22.png"!



!Screenshot 2024-05-15 at 15.29.31.png|width=91.66666666666666%,alt="Screenshot 2024-05-15 at 15.29.31.png"!



!Screenshot 2024-05-15 at 15.25.32.png|width=75%,alt="Screenshot 2024-05-15 at 15.25.32.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
