### PR TITLE
PNC batch job does not count meta_data correctly

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/juror/pnc/check/support/IntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/juror/pnc/check/support/IntegrationTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.juror.pnc.check.client.contracts.JobExecutionServiceClient;
+import uk.gov.hmcts.juror.pnc.check.client.contracts.JurorServiceClient;
 import uk.gov.hmcts.juror.pnc.check.config.RemoteConfig;
 import uk.gov.hmcts.juror.pnc.check.model.JurorCheckBatch;
 import uk.gov.hmcts.juror.pnc.check.model.JurorCheckRequest;
@@ -106,7 +107,9 @@ public abstract class IntegrationTest {
     protected void beforeEach() {
         WireMock.stubFor(WireMock.patch(urlPathTemplate(config.getJurorService().getUrl()))
             .withHeader(HttpHeaders.CONTENT_TYPE, WireMock.containing("application/json"))
-            .willReturn(WireMock.status(HttpStatus.ACCEPTED.value())
+            .willReturn(WireMock.jsonResponse(
+                new JurorServiceClient.PoliceCheckStatusDto(PoliceNationalComputerCheckResult.Status.ELIGIBLE),
+                    HttpStatus.ACCEPTED.value())
                 .withHeader(HttpHeaders.CONNECTION, "close")));
     }
 
@@ -407,6 +410,7 @@ public abstract class IntegrationTest {
         return new BulkRequest(jurorCheckRequest, personResponse,
             PoliceNationalComputerCheckResult.Status.ELIGIBLE);
     }
+
 
     protected BulkRequest createBulkRequestOnBail(JurorCheckRequest jurorCheckRequest) {
         GetPersonDetailsResponse personResponse = createGetPersonDetailsResponse(jurorCheckRequest, "", true, null);

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/client/JurorServiceClientImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/client/JurorServiceClientImpl.java
@@ -35,7 +35,7 @@ public class JurorServiceClientImpl extends AbstractRemoteRestClient implements 
 
     @Override
     public PoliceCheckStatusDto call(String jurorNumber, PoliceCheckStatusDto payload) {
-        log.debug("Updating juror: " + jurorNumber + " pnc check result on juror service backend");
+        log.debug("Updating juror: {} pnc check result on juror service backend", jurorNumber);
         HttpEntity<PoliceCheckStatusDto> requestUpdate = new HttpEntity<>(payload);
         ResponseEntity<PoliceCheckStatusDto> response =
             restTemplate.exchange(url, HttpMethod.PATCH, requestUpdate, PoliceCheckStatusDto.class, jurorNumber);
@@ -43,7 +43,7 @@ public class JurorServiceClientImpl extends AbstractRemoteRestClient implements 
         if (!statusCode.equals(HttpStatus.ACCEPTED)) {
             throw new RemoteGatewayException("Call to JurorServiceClient failed status code was: " + statusCode);
         }
-        log.debug("Successfully updating juror: " + jurorNumber + " pnc check result on juror service backend");
+        log.debug("Successfully updating juror: {} pnc check result on juror service backend", jurorNumber);
         return response.getBody();
     }
 }

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/client/contracts/JurorServiceClient.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/client/contracts/JurorServiceClient.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.juror.pnc.check.client.contracts;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import uk.gov.hmcts.juror.pnc.check.model.PoliceNationalComputerCheckResult;
 import uk.gov.hmcts.juror.standard.client.contract.Client;
 
@@ -11,6 +12,7 @@ public interface JurorServiceClient extends Client {
     PoliceCheckStatusDto call(String jurorNumber, PoliceCheckStatusDto result);
 
     @AllArgsConstructor
+    @NoArgsConstructor
     @Getter
     @EqualsAndHashCode
     class PoliceCheckStatusDto {

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/model/JurorCheckBatch.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/model/JurorCheckBatch.java
@@ -35,7 +35,7 @@ public class JurorCheckBatch {
 
     public void incrementResultsCounter() {
         this.countDownLatch.countDown();
-        log.trace(this.countDownLatch.getCount() + " checks left in this batch");
+        log.trace("{} checks left in this batch", this.countDownLatch.getCount());
     }
 
     public long getTotalResults() {

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/model/PoliceNationalComputerCheckResult.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/model/PoliceNationalComputerCheckResult.java
@@ -21,11 +21,6 @@ public class PoliceNationalComputerCheckResult {
         return new PoliceNationalComputerCheckResult(Status.ELIGIBLE);
     }
 
-    @Override
-    public String toString() {
-        return "Result: " + this.status + " Message: " + this.message;
-    }
-
     public enum Status {
         ELIGIBLE,
         INELIGIBLE,

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/rules/disposal/DisposalMustNotEndWithInRule.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/rules/disposal/DisposalMustNotEndWithInRule.java
@@ -48,9 +48,8 @@ public class DisposalMustNotEndWithInRule extends DisposalRule {
         final Calendar maximumAllowedEndDate = getMaximumAllowedEndDate();
 
         if (log.isDebugEnabled()) {
-            log.debug(
-                "Sentence must end before: " + slashDateFormat.format(Date.from(maximumAllowedEndDate.toInstant()))
-                    + "\nSentence ended at: " + slashDateFormat.format(
+            log.debug("Sentence must end before: {}\nSentence ended at: {}",
+                slashDateFormat.format(Date.from(maximumAllowedEndDate.toInstant())), slashDateFormat.format(
                     Date.from(effectiveEndOfSentenceCalendar.toInstant())));
         }
         return !effectiveEndOfSentenceCalendar.after(maximumAllowedEndDate);
@@ -108,7 +107,7 @@ public class DisposalMustNotEndWithInRule extends DisposalRule {
                 date = noSlashDateFormat.parse(dateStr);
             }
         } catch (ParseException e) {
-            log.error("stringToDate Error parsing a date " + dateStr);
+            log.error("stringToDate Error parsing a date {}", dateStr);
             throw new InternalServerException("Unable to parse date string: '" + dateStr + "'", e);
         }
         Calendar calendar = Calendar.getInstance();

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/rules/support/DisposalRule.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/rules/support/DisposalRule.java
@@ -34,7 +34,7 @@ public abstract class DisposalRule extends Rule<DisposalDto> {
     public boolean validate(DisposalDto value) {
         Integer disposalCode = Utilities.getInteger(value.getDisposalCode());
         if (!supportedCodes.isEmpty() && (disposalCode == null || !supportedCodes.contains(disposalCode))) {
-            log.debug("Skipping rule: " + this.getName() + " disposal code not supported");
+            log.debug("Skipping rule: {} disposal code not supported", this.getName());
             return true;
         }
         return super.validate(value);

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/rules/support/Rule.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/rules/support/Rule.java
@@ -27,9 +27,9 @@ public abstract class Rule<T> {
         if (failOnPass) {
             result = !result;
         }
-        log.debug("Rule: " + this.getName() + ": " + (result
+        log.trace("Rule: {}: {}", this.getName(), result
             ? "PASSED"
-            : "FAILED"));
+            : "FAILED");
         return result;
     }
 

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
@@ -55,10 +55,10 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
     @Override
     public PoliceNationalComputerCheckResult performPoliceCheck(
         final JurorCheckDetails jurorCheckDetails) {
-        log.info("Performing police check for Juror: " + jurorCheckDetails.getJurorNumber());
+        log.info("Performing police check for Juror: {}", jurorCheckDetails.getJurorNumber());
         PoliceNationalComputerCheckResult result = getPoliceCheckResult(jurorCheckDetails);
         savePoliceCheckResult(jurorCheckDetails, result);
-        log.info("Juror check complete for juror: " + jurorCheckDetails.getJurorNumber());
+        log.info("Juror check complete for juror: {}", jurorCheckDetails.getJurorNumber());
         return result;
     }
 
@@ -87,22 +87,21 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
     }
 
     private void savePoliceCheckResult(JurorCheckDetails jurorCheckDetails, PoliceNationalComputerCheckResult result) {
-        jurorCheckDetails.setResult(result);
-        log.trace("Attempting to save result: " + result + " for juror " + jurorCheckDetails.getJurorNumber());
         if (result != null) {
             try {
                 JurorServiceClient.PoliceCheckStatusDto policeCheckStatusDto =
                     this.jurorServiceClient.call(jurorCheckDetails.getJurorNumber(),
                         new JurorServiceClient.PoliceCheckStatusDto(result.getStatus()));
-
                 result.setMaxRetiresExceed(policeCheckStatusDto.getStatus()
                     .equals(PoliceNationalComputerCheckResult.Status.UNCHECKED_MAX_RETRIES_EXCEEDED));
-                log.info("Juror check result saved for juror: " + jurorCheckDetails.getJurorNumber());
-            } catch (RemoteGatewayException exception) {
+                log.info("Juror check result saved for juror: {}", jurorCheckDetails.getJurorNumber());
+            } catch (Throwable exception) {
                 result.setStatus(PoliceNationalComputerCheckResult.Status.ERROR_RETRY_FAILED_TO_UPDATE_BACKEND);
-                log.error("Failed to save juror result on backend: " + jurorCheckDetails.getJurorNumber(), exception);
+                log.error("Failed to save juror result on backend: {}", jurorCheckDetails.getJurorNumber(), exception);
             }
         }
+        jurorCheckDetails.setResult(result);
+        log.trace("Attempting to save result: {} for juror {}", result, jurorCheckDetails.getJurorNumber());
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
@@ -69,7 +69,7 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
                     .mapJurorCheckRequestToGetPersonDetails(jurorCheckDetails);
 
             if (getPersonDetails.getSearchName().matches(".*\\d.*")) {
-                log.warn("Juror: " + jurorCheckDetails.getJurorNumber() + " not processed as name contains numerics");
+                log.warn("Juror: {} not processed as name contains numerics", jurorCheckDetails.getJurorNumber());
                 return new PoliceNationalComputerCheckResult(
                     PoliceNationalComputerCheckResult.Status.ERROR_RETRY_NAME_HAS_NUMERICS);
             }
@@ -95,7 +95,7 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
                 result.setMaxRetiresExceed(policeCheckStatusDto.getStatus()
                     .equals(PoliceNationalComputerCheckResult.Status.UNCHECKED_MAX_RETRIES_EXCEEDED));
                 log.info("Juror check result saved for juror: {}", jurorCheckDetails.getJurorNumber());
-            } catch (Throwable exception) {
+            } catch (Exception exception) {
                 result.setStatus(PoliceNationalComputerCheckResult.Status.ERROR_RETRY_FAILED_TO_UPDATE_BACKEND);
                 log.error("Failed to save juror result on backend: {}", jurorCheckDetails.getJurorNumber(), exception);
             }
@@ -167,15 +167,15 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
 
     PoliceNationalComputerCheckResult validatePoliceCheckResponse(String jurorNumber,
                                                                   @NotNull PersonDetailsDto personDetails) {
-        log.info("Validating Juror: " + jurorNumber);
+        log.info("Validating Juror: {}", jurorNumber);
         Optional<PoliceNationalComputerCheckResult> resultOptional = checkErrorReason(jurorNumber, personDetails);
         if (resultOptional.isPresent()) {
-            log.info("Error Reason checks failed for juror: " + jurorNumber);
+            log.trace("Error Reason checks failed for juror: {}", jurorNumber);
             return resultOptional.get();
         }
-        log.info("Error Reason checks passed for juror: " + jurorNumber);
-        log.info("Validating person details for juror: " + jurorNumber + " - "
-            + personDetails.getPersonDtos().size() + " persons entries found");
+        log.trace("Error Reason checks passed for juror: {}", jurorNumber);
+        log.trace("Validating person details for juror: {} - {} persons entries found", jurorNumber,
+            personDetails.getPersonDtos().size());
         for (PersonDto person : personDetails.getPersonDtos()) {
             RuleValidationResult ruleValidationResult = this.ruleService.fireRules(RuleSets.PERSON_RULE_SET, person);
 
@@ -187,7 +187,7 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
             }
 
             if (!ruleValidationResult.isPassed()) {
-                log.info("Validation rules failed for juror: " + jurorNumber);
+                log.trace("Validation rules failed for juror: {}", jurorNumber);
                 return new PoliceNationalComputerCheckResult(PoliceNationalComputerCheckResult.Status.INELIGIBLE,
                     ruleValidationResult.getMessage());
             }
@@ -201,9 +201,9 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
         final PersonDetailsDto personDetailsDto) {
 
         final String errorReason = personDetailsDto.getErrorReason();
-        log.info("ResponseCode: " + errorReason);
+        log.info("ResponseCode: {}", errorReason);
         if (errorReason == null) {
-            log.info("No data returned for juror " + jurorNumber);
+            log.info("No data returned for juror {}", jurorNumber);
             return Optional.of(
                 new PoliceNationalComputerCheckResult(
                     PoliceNationalComputerCheckResult.Status.ERROR_RETRY_NO_ERROR_REASON,
@@ -212,11 +212,10 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
 
         if (!errorReason.isBlank()) {
             if (errorReason.startsWith(Constants.NO_RECORDS_FOUND_ERROR_CODE)) {
-                log.debug("No PNC data for juror " + jurorNumber + ", response code " + errorReason);
+                log.debug("No PNC data for juror {}, response code {}", jurorNumber, errorReason);
                 return Optional.empty();// Pass if onBail check passes
             } else {
-                log.error("Error checking juror " + jurorNumber);
-                log.error("Returned error code: " + errorReason + ", for juror " + jurorNumber);
+                log.error("Error checking juror {}", jurorNumber);
                 return Optional.of(
                     new PoliceNationalComputerCheckResult(
                         PoliceNationalComputerCheckResult.Status.ERROR_RETRY_OTHER_ERROR_CODE,

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/service/QueueServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/service/QueueServiceImpl.java
@@ -51,7 +51,7 @@ public class QueueServiceImpl implements QueueService {
         "java:S2142"
     })
     public void queueRequests(Collection<JurorCheckDetails> requests, JurorCheckBatch.MetaData metaData) {
-        log.info(requests.size() + " checks are being queued");
+        log.info("{} checks are being queued", requests.size());
         final JurorCheckBatch jurorCheckBatch = new JurorCheckBatch(
             Optional.ofNullable(metaData)
                 .orElseGet(() -> JurorCheckBatch.MetaData.builder()

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/service/RuleServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/service/RuleServiceImpl.java
@@ -73,7 +73,7 @@ public class RuleServiceImpl implements RuleService {
     )
     Rule<?> createRuleFromRuleConfig(RuleConfig.ConditionalRule conditionalRule) {
         if (conditionalRule.getConditions() == null || conditionalRule.getConditions().isEmpty()) {
-            log.info("Using AllowedDisposalCodes as no conditions found for rule: " + conditionalRule);
+            log.trace("Using AllowedDisposalCodes as no conditions found for rule: {}", conditionalRule);
             return new AllowedDisposalCodesRule(conditionalRule.getWhenCodeIsOneOf(), false);
         }
         AndRule disposalAndRule = new AndRule(conditionalRule.getWhenCodeIsOneOf(), false);
@@ -118,7 +118,7 @@ public class RuleServiceImpl implements RuleService {
     @Override
     @SuppressWarnings("unchecked")
     public <T> RuleValidationResult fireRules(@NotNull RuleSet<T> ruleSet, Collection<T> values) {
-        log.trace("Triggering rules for: " + ruleSet.getSupportedClass());
+        log.trace("Triggering rules for: {}", ruleSet.getSupportedClass());
         final Optional<List<Rule<?>>> rulesOptional = Optional.ofNullable(rulesetsMap.get(ruleSet));
         if (rulesOptional.isEmpty()) {
             throw new InternalServerException("Ruleset for "
@@ -130,8 +130,7 @@ public class RuleServiceImpl implements RuleService {
                 .filter(rule -> !(((Rule<T>) rule).validate(value)))
                 .findFirst();
             if (ruleOptional.isPresent()) {
-                log.info("Rule failed " + ruleOptional.get().getDescription());
-                log.debug("Value: " + value);
+                log.trace("Rule failed {}", ruleOptional.get().getDescription());
                 return RuleValidationResult.failed(ruleOptional.get().getDescription());
             }
         }

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/utils/Utilities.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/utils/Utilities.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.juror.pnc.check.utils;
 
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
 
@@ -18,17 +17,10 @@ public final class Utilities {
             .replaceAll("\\[[^]]*]", "") //Remove square braces
             .replaceAll("[^/_'A-Za-z0-9 -]", "") //Removes all none support characters
             .replaceAll("\\s+", "") //Removes spaces
-        ;
-        if (!originalTextToClean.equals(textBeingCleaned)) {
-            log.info("Juror name " + originalTextToClean + " contained unsupported chars and has been changed to "
-                + textBeingCleaned);
-        }
+            ;
+        log.trace("Juror name {} contained unsupported chars and has been changed to {}", originalTextToClean,
+            textBeingCleaned);
         return textBeingCleaned;
-    }
-
-    @SneakyThrows
-    public static void sleep(long timeMs) {
-        Thread.sleep(timeMs);
     }
 
     public static Integer getInteger(String intString) {
@@ -38,7 +30,7 @@ public final class Utilities {
         try {
             return Integer.parseInt(intString);
         } catch (NumberFormatException e) {
-            log.error("Unable to parse input ' " + intString + "' into an integer", e);
+            log.error("Unable to parse input ' {}' into an integer", intString, e);
             return null;
         }
     }

--- a/src/test/java/uk/gov/hmcts/juror/pnc/check/model/PoliceNationalComputerCheckResultTest.java
+++ b/src/test/java/uk/gov/hmcts/juror/pnc/check/model/PoliceNationalComputerCheckResultTest.java
@@ -18,8 +18,6 @@ class PoliceNationalComputerCheckResultTest {
 
         assertEquals(status, result.getStatus(), "Status should match");
         assertEquals(message, result.getMessage(), "Message should match");
-        assertEquals(getExpectedToString(status, message), result.toString(),
-            "ToString should be describe the result");
     }
 
 
@@ -30,8 +28,6 @@ class PoliceNationalComputerCheckResultTest {
 
         assertEquals(status, result.getStatus(), "Status should match");
         assertNull(result.getMessage(), "Message should not be present");
-        assertEquals(getExpectedToString(status, null), result.toString(),
-            "ToString should be describe the result");
     }
 
     @Test
@@ -40,12 +36,5 @@ class PoliceNationalComputerCheckResultTest {
 
         assertEquals(PoliceNationalComputerCheckResult.Status.ELIGIBLE, result.getStatus(), "Status should be  passed");
         assertNull(result.getMessage(), "Message should not be present");
-        assertEquals(getExpectedToString(PoliceNationalComputerCheckResult.Status.ELIGIBLE, null), result.toString(),
-            "ToString should be describe the result");
-    }
-
-
-    private String getExpectedToString(PoliceNationalComputerCheckResult.Status status, String message) {
-        return "Result: " + status.name() + " Message: " + message;
     }
 }


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7297)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=176)


### Change description ###
PNC scheduler batch job reports MAX_RETRIES_EXCEEDED count as 0 even when there are jurors updated to that status. It counts them in the {{TOTAL_WITH_STATUS_ERROR_RETRY_OTHER_ERROR_CODE}}



!Screenshot 2024-05-15 at 15.27.22.png|width=100%,alt="Screenshot 2024-05-15 at 15.27.22.png"!



!Screenshot 2024-05-15 at 15.29.31.png|width=91.66666666666666%,alt="Screenshot 2024-05-15 at 15.29.31.png"!



!Screenshot 2024-05-15 at 15.25.32.png|width=75%,alt="Screenshot 2024-05-15 at 15.25.32.png"!

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
