### PR TITLE
Police check incorrectly marks jurors as OTHER_ERROR_CODE when no record could be found

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/juror/pnc/check/EligibilityCheckSingleTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/juror/pnc/check/EligibilityCheckSingleTest.java
@@ -208,7 +208,20 @@ class EligibilityCheckSingleTest extends IntegrationTest {
         performValidSingle(
             jurorCheckRequest,
             createGetPersonDetailsResponse(jurorCheckRequest,
-                "JUR001 - No Records Found: abc", false, null),
+                "JUR001 - No records found: abc", false, null),
+            PoliceNationalComputerCheckResult.Status.ELIGIBLE
+        );
+    }
+
+    @Test
+    @DisplayName("ELIGIBLE: Error Reason starts with 'Jur001 - No Records foUnd:' - Mixed Case")
+    @SuppressWarnings("AbbreviationAsWordInName")
+    void eligibleErrorReasonStartsWithJur001MixedCase() throws Exception {
+        JurorCheckRequest jurorCheckRequest = getTypicalJurorCheckRequest();
+        performValidSingle(
+            jurorCheckRequest,
+            createGetPersonDetailsResponse(jurorCheckRequest,
+                "Jur001 - No Records foUnd: abc", false, null),
             PoliceNationalComputerCheckResult.Status.ELIGIBLE
         );
     }

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/config/Constants.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/config/Constants.java
@@ -6,7 +6,7 @@ import java.util.Locale;
 public final class Constants {
 
     public static final String DEFAULT_PERSON_DETAILS_LOCATION = "MOJ";
-    public static final String NO_RECORDS_FOUND_ERROR_CODE = "JUR001 - No Records Found:";
+    public static final String NO_RECORDS_FOUND_ERROR_CODE = "JUR001";
     public static final Locale LOCALE = Locale.UK;
     public static final int MAX_BULK_CHECKS = 500;
 

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.juror.pnc.check.service.contracts.RuleService;
 import uk.gov.hmcts.juror.standard.service.exceptions.RemoteGatewayException;
 import uk.police.npia.juror.schema.v1.GetPersonDetails;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -210,7 +211,8 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
                     "No data returned for juror. Unable to check"));
         }
         if (!errorReason.isBlank()) {
-            if (errorReason.toLowerCase().contains(Constants.NO_RECORDS_FOUND_ERROR_CODE.toLowerCase())) {
+            if (errorReason.toLowerCase(Locale.getDefault())
+                .contains(Constants.NO_RECORDS_FOUND_ERROR_CODE.toLowerCase(Locale.getDefault()))) {
                 log.debug("No PNC data for juror {}, response code {}", jurorNumber, errorReason);
                 return Optional.empty();// Pass if onBail check passes
             } else {

--- a/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/juror/pnc/check/service/PoliceNationalComputerCheckServiceImpl.java
@@ -209,9 +209,8 @@ public class PoliceNationalComputerCheckServiceImpl implements PoliceNationalCom
                     PoliceNationalComputerCheckResult.Status.ERROR_RETRY_NO_ERROR_REASON,
                     "No data returned for juror. Unable to check"));
         }
-
         if (!errorReason.isBlank()) {
-            if (errorReason.startsWith(Constants.NO_RECORDS_FOUND_ERROR_CODE)) {
+            if (errorReason.toLowerCase().contains(Constants.NO_RECORDS_FOUND_ERROR_CODE.toLowerCase())) {
                 log.debug("No PNC data for juror {}, response code {}", jurorNumber, errorReason);
                 return Optional.empty();// Pass if onBail check passes
             } else {


### PR DESCRIPTION
### Links ###
>[Jira](https://centralgovernmentcgi.atlassian.net/browse/JM-7768)
>[Sonar](https://sonarcloud.io/summary/new_code?id=uk.gov.hmcts.juror%3Ahmcts&pullRequest=184)


### Change description ###
{{ERROR_RETRY_OTHER_ERROR_CODE}} we want to update the status in progress

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
